### PR TITLE
only generate measurements for a few stations

### DIFF
--- a/database/seeds/MeasurementSeeder.php
+++ b/database/seeds/MeasurementSeeder.php
@@ -7,6 +7,8 @@ use Carbon\Carbon;
 
 class MeasurementSeeder extends Seeder
 {
+    // only generate lots of data for stations close to Kyoto
+    private $between = [134, 136];
     private $seedAmount = 2000;
     private $randomValueWindow = 0.003;
 
@@ -17,12 +19,13 @@ class MeasurementSeeder extends Seeder
      */
     public function run()
     {
-        $stations = Station::all();
-        $data = [];
-        $temp = [];
-
-        foreach ($stations as $station) {
+        $stations = Station::where('longitude', '>', $this->between[0])
+                           ->where('longitude', '<', $this->between[1]);
+        foreach ($stations->get() as $station) {
+            $date = Carbon::now();
             $temp = [
+                'stn' => $station->id,
+                'timestamp' => $date->format(DateTime::ATOM),
                 'temp' => $this->getRandomDouble(-30, 40, 1),
                 'dewp' => $this->getRandomDouble(-40, 35, 1),
                 'stp' => $this->getRandomDouble(900, 1100, 1),
@@ -30,15 +33,21 @@ class MeasurementSeeder extends Seeder
                 'visib' => $this->getRandomDouble(0, 165, 1),
                 'prcp' => $this->getRandomDouble(0, 15, 1),
                 'sndp' => $this->getRandomDouble(0, 90, 1),
+                'frshtt' => (rand(0, 1) . rand(0, 1)
+                    . rand(0, 1) . rand(0, 1) . rand(0, 1)
+                    . rand(0, 1)),
                 'ddc' => $this->getRandomDouble(0, 100, 1),
                 'wnddir' => rand(0, 359),
                 'wdsp' => $this->getRandomDouble(0, 80, 1)
             ];
 
+            $data = [$temp];
             for ($i = 0; $i < $this->seedAmount; $i++) {
-                $data[] = [
+                // travel back in tiiime!
+                $date->subSecond();
+                $temp = [
                     'stn' => $station->id,
-                    'timestamp' => Carbon::now(),
+                    'timestamp' => $date->format(DateTime::ATOM),
                     'temp' => $this->createRandomValueBasedOn($temp['temp']),
                     'dewp' => $this->createRandomValueBasedOn($temp['dewp']),
                     'stp' => $this->createRandomValueBasedOn($temp['stp']),
@@ -53,10 +62,10 @@ class MeasurementSeeder extends Seeder
                     'wnddir' => $this->createRandomValueBasedOn($temp['wnddir']),
                     'wdsp' => $this->createRandomValueBasedOn($temp['wdsp'])
                 ];
+                $data[] = $temp;
             }
+            DB::table('measurements')->insert($data);
         }
-
-        DB::table('measurements')->insert($data);
     }
 
     /**


### PR DESCRIPTION
Generating 2k measurements for 8k stations is a lot of measurements,
and takes a long time and lots of memory. This only generates
measurements for a few stations that are close to Kyoto (our target)
and inserts them in batches of ~2000.