### PR TITLE
fix for seeding

### DIFF
--- a/database/seeds/StationTableSeeder.php
+++ b/database/seeds/StationTableSeeder.php
@@ -11,6 +11,7 @@ class StationTableSeeder extends Seeder
      */
     public function run()
     {
+        DB::table('stations')->truncate();
         $insertArray = array();
         $stations = file_get_contents(base_path().'/resources/stations.tsv');
         $stationArray = explode(PHP_EOL, $stations);


### PR DESCRIPTION
Voorheen bleef de seeder hier hangen als je de stations al ingevuld had in verband met duplicated keys.